### PR TITLE
FPS-independent third person camera damping

### DIFF
--- a/CODE-mp/cgame/cg_ents.c
+++ b/CODE-mp/cgame/cg_ents.c
@@ -2359,6 +2359,7 @@ void CG_PreparePacketEntities( void ) {
 	} else {
 		cg.frameInterpolation = 0;	// actually, it should never be used, because 
 									// no entities should be marked as interpolating
+		cg.predictedTimeFrac = 0.0f;
 	}
 
 	// the auto-rotating items will all have the same axis

--- a/CODE-mp/cgame/cg_local.h
+++ b/CODE-mp/cgame/cg_local.h
@@ -719,6 +719,7 @@ typedef struct {
 //	snapshot_t	activeSnapshots[2];
 
 	float		frameInterpolation;	// (float)( cg.time - cg.frame->serverTime ) / (cg.nextFrame->serverTime - cg.frame->serverTime)
+	float		predictedTimeFrac;	// frameInterpolation * (next->commandTime - prev->commandTime)
 
 	qboolean	mMapChange;
 
@@ -1730,6 +1731,7 @@ extern	vmCvar_t	mov_captureCvars;
 extern	vmCvar_t	mov_ratioFix;
 extern	vmCvar_t	mov_saberTeamColour;
 extern	vmCvar_t	mov_wallhack;
+extern	vmCvar_t	mov_camerafps;
 
 extern	vmCvar_t	mov_dismember;
 extern	vmCvar_t	mov_forceNTdemo;

--- a/CODE-mp/cgame/cg_main.c
+++ b/CODE-mp/cgame/cg_main.c
@@ -605,6 +605,7 @@ vmCvar_t	mov_captureCvars;
 vmCvar_t	mov_ratioFix;
 vmCvar_t	mov_saberTeamColour;
 vmCvar_t	mov_wallhack;
+vmCvar_t	mov_camerafps;
 
 vmCvar_t	mov_dismember;
 vmCvar_t	mov_forceNTdemo;
@@ -817,6 +818,7 @@ Ghoul2 Insert End
 	{ &mov_ratioFix,		"mov_ratioFix",			"1",   CG_Set2DRatio,	CVAR_ARCHIVE	},
 	{ &mov_saberTeamColour,	"mov_saberTeamColour",	"1",			NULL,	CVAR_ARCHIVE	},
 	{ &mov_wallhack,		"mov_wallhack",			"0",			NULL,	CVAR_ARCHIVE	},
+	{ &mov_camerafps,		"mov_camerafps",		"125",			NULL,	CVAR_ARCHIVE	},
 	{ &mov_dismember,		"mov_dismember",		"0",			NULL,	CVAR_ARCHIVE	},
 	{ &mov_forceNTdemo,		"mov_forceNTdemo",		"0",  CG_ForceNTDemo,	CVAR_ARCHIVE	},
 	{ &mov_absorbVisibility,"mov_absorbVisibility",	"0",			NULL,	CVAR_ARCHIVE	},

--- a/CODE-mp/cgame/cg_predict.c
+++ b/CODE-mp/cgame/cg_predict.c
@@ -277,6 +277,7 @@ void CG_InterpolatePlayerState( qboolean grabAngles ) {
 			f * (next->ps.velocity[i] - prev->ps.velocity[i] );
 	}
 
+	cg.predictedTimeFrac = f * (next->ps.commandTime - prev->ps.commandTime);
 }
 
 /*
@@ -838,6 +839,8 @@ void CG_PredictPlayerState( void ) {
 			CG_Printf("WARNING: dropped event\n");
 		}
 	}
+
+	cg.predictedTimeFrac = 0.0f;
 
 	// fire events and other transition triggered things
 	CG_TransitionPlayerState( &cg.predictedPlayerState, &oldPlayerState );

--- a/CODE-mp/cgame/cg_view.c
+++ b/CODE-mp/cgame/cg_view.c
@@ -217,7 +217,7 @@ static void CG_StepOffset( void ) {
 }
 
 #define CAMERA_DAMP_INTERVAL	50
-#define CAMERA_MIN_FPS			15
+#define CAMERA_MIN_FPS			1
 
 static vec3_t	cameramins = { -CAMERA_SIZE, -CAMERA_SIZE, -CAMERA_SIZE };
 static vec3_t	cameramaxs = { CAMERA_SIZE, CAMERA_SIZE, CAMERA_SIZE };

--- a/CODE-mp/cgame/cg_view.c
+++ b/CODE-mp/cgame/cg_view.c
@@ -678,13 +678,10 @@ static void CG_OffsetThirdPersonView( void )
 	VectorNormalize(diff);
 	vectoangles(diff, cg.refdefViewAngles);*/
 	VectorSubtract(cameraCurTarget, cameraCurLoc, diff);
+	if (VectorLengthSquared(diff) < 0.01f * 0.01f)
 	{
-		float dist = VectorNormalize(diff);
-		//under normal circumstances, should never be 0.00000 and so on.
-		if ( !dist || (diff[0] == 0 || diff[1] == 0) )
-		{//must be hitting something, need some value to calc angles, so use cam forward
-			VectorCopy( camerafwd, diff );
-		}
+	    //must be hitting something, need some value to calc angles, so use cam forward
+	    VectorCopy( camerafwd, diff );
 	}
 	vectoangles(diff, cg.refdefViewAngles);
 

--- a/CODE-mp/cgame/cg_view.c
+++ b/CODE-mp/cgame/cg_view.c
@@ -11,7 +11,6 @@
 #define MASK_CAMERACLIP (MASK_SOLID|CONTENTS_PLAYERCLIP)
 #define CAMERA_SIZE	4
 
-
 static int GetCameraClip( void ) {
 	return (MASK_SOLID|CONTENTS_PLAYERCLIP);
 }
@@ -218,6 +217,7 @@ static void CG_StepOffset( void ) {
 }
 
 #define CAMERA_DAMP_INTERVAL	50
+#define CAMERA_MIN_FPS			15
 
 static vec3_t	cameramins = { -CAMERA_SIZE, -CAMERA_SIZE, -CAMERA_SIZE };
 static vec3_t	cameramaxs = { CAMERA_SIZE, CAMERA_SIZE, CAMERA_SIZE };
@@ -227,7 +227,8 @@ vec3_t	cameraFocusAngles,			cameraFocusLoc;
 vec3_t	cameraIdealTarget,			cameraIdealLoc;
 vec3_t	cameraCurTarget={0,0,0},	cameraCurLoc={0,0,0};
 vec3_t	cameraOldLoc={0,0,0},		cameraNewLoc={0,0,0};
-int		cameraLastFrame=0;
+int		cameraLastTime=0;
+float	cameraLastTimeFrac=0.0f;
 
 float	cameraLastYaw=0;
 float	cameraStiffFactor=0.0f;
@@ -345,7 +346,8 @@ static void CG_ResetThirdPersonViewDamp(void)
 		VectorCopy(trace.endpos, cameraCurLoc);
 	}
 
-	cameraLastFrame = cg.time;
+	cameraLastTime = cg.predictedPlayerState.commandTime;
+	cameraLastTimeFrac = cg.predictedTimeFrac;
 	cameraLastYaw = cameraFocusAngles[YAW];
 	cameraStiffFactor = 0.0f;
 }
@@ -355,11 +357,18 @@ static void CG_UpdateThirdPersonTargetDamp(void)
 {
 	trace_t trace;
 	vec3_t	targetdiff;
+	vec3_t	oldDelta;
+	vec3_t	idealDelta;
 	float	dampfactor, dtime, ratio;
+
+	VectorSubtract(cameraCurTarget, cameraIdealTarget, oldDelta);
+	VectorCopy(cameraIdealTarget, idealDelta);
 
 	// Set the cameraIdealTarget
 	// Automatically get the ideal target, to avoid jittering.
 	CG_CalcIdealThirdPersonViewTarget();
+
+	VectorSubtract(cameraIdealTarget, idealDelta, idealDelta);
 
 	if (cg_thirdPersonTargetDamp.value>=1.0)
 	{	// No damping.
@@ -367,21 +376,60 @@ static void CG_UpdateThirdPersonTargetDamp(void)
 	}
 	else if (cg_thirdPersonTargetDamp.value>=0.0)
 	{	
-		// Calculate the difference from the current position to the new one.
-		VectorSubtract(cameraIdealTarget, cameraCurTarget, targetdiff);
-
-		// Now we calculate how much of the difference we cover in the time allotted.
-		// The equation is (Damp)^(time)
 		dampfactor = 1.0-cg_thirdPersonTargetDamp.value;	// We must exponent the amount LEFT rather than the amount bled off
-		dtime = (float)(cg.time-cameraLastFrame) * (1.0/(float)CAMERA_DAMP_INTERVAL);	// Our dampfactor is geared towards a time interval equal to "1".
 
-		// Note that since there are a finite number of "practical" delta millisecond values possible, 
-		// the ratio should be initialized into a chart ultimately.
-		ratio = Q_powf(dampfactor, dtime);
-		
-		// This value is how much distance is "left" from the ideal.
-		VectorMA(cameraIdealTarget, -ratio, targetdiff, cameraCurTarget);
-		/////////////////////////////////////////////////////////////////////////////////////////////////////////
+		if ( mov_camerafps.integer >= CAMERA_MIN_FPS )
+		{	// FPS-independent camera damping by fau
+			vec3_t	newDelta;
+			vec3_t	velocity;
+			vec3_t	shift;
+			float	invdtime;
+			float	timeadjfactor;
+			float	codampfactor;
+			int		simulationtime;
+			float	physicstime;
+
+			// use physics time to get a real velocity
+			physicstime = cg.predictedPlayerState.commandTime - cameraLastTime;
+			physicstime += cg.predictedTimeFrac - cameraLastTimeFrac;
+			if (physicstime <= 0.0f)
+				return;
+			simulationtime = 1000 / mov_camerafps.integer;
+			dtime = physicstime / simulationtime;
+			invdtime = simulationtime / physicstime;
+			timeadjfactor = powf(dampfactor, dtime);
+			// velocity is in units / simulated frame time
+			VectorScale(idealDelta, invdtime, velocity);
+			// shift = velocity * dampfactor / (1 - dampfactor)
+			codampfactor = dampfactor / (1.0f - dampfactor);
+			VectorScale(velocity, codampfactor, shift);
+			// delta(dtime) = dampfactor^dtime * (delta(0) + shift) - shift
+			newDelta[0] = timeadjfactor * (oldDelta[0] + shift[0]) - shift[0];
+			newDelta[1] = timeadjfactor * (oldDelta[1] + shift[1]) - shift[1];
+			newDelta[2] = timeadjfactor * (oldDelta[2] + shift[2]) - shift[2];
+
+			VectorAdd(cameraIdealTarget, newDelta, cameraCurTarget);
+		}
+		else
+		{
+			// Calculate the difference from the current position to the new one.
+			VectorSubtract(cameraIdealTarget, cameraCurTarget, targetdiff);
+
+			// Now we calculate how much of the difference we cover in the time allotted.
+			// The equation is (Damp)^(time)
+
+			// Note that since there are a finite number of "practical" delta millisecond values possible,
+			// the ratio should be initialized into a chart ultimately.
+			// dtime = (float)(cg.time-cameraLastFrame) * (1.0/(float)CAMERA_DAMP_INTERVAL);	// Our dampfactor is geared towards a time interval equal to "1".
+			// ratio = powi(dampfactor, dtime);
+
+			// fau - and this is how original powi really worked in mp when fps > 20
+			ratio = dampfactor;
+
+			// This value is how much distance is "left" from the ideal.
+			VectorMA(cameraIdealTarget, -ratio, targetdiff, cameraCurTarget);
+			/////////////////////////////////////////////////////////////////////////////////////////////////////////
+		}
 	}
 
 	// Now we trace to see if the new location is cool or not.
@@ -404,11 +452,17 @@ static void CG_UpdateThirdPersonCameraDamp(void)
 {
 	trace_t trace;
 	vec3_t	locdiff;
+	vec3_t	oldDelta;
+	vec3_t	idealDelta;
 	float dampfactor, dtime, ratio;
+
+	VectorSubtract(cameraCurLoc, cameraIdealLoc, oldDelta);
+	VectorCopy(cameraIdealLoc, idealDelta);
 
 	// Set the cameraIdealLoc
 	CG_CalcIdealThirdPersonViewLocation();
 	
+	VectorSubtract(cameraIdealLoc, idealDelta, idealDelta);
 	
 	// First thing we do is calculate the appropriate damping factor for the camera.
 	dampfactor=0.0;
@@ -438,21 +492,60 @@ static void CG_UpdateThirdPersonCameraDamp(void)
 	}
 	else if (dampfactor>=0.0)
 	{	
-		// Calculate the difference from the current position to the new one.
-		VectorSubtract(cameraIdealLoc, cameraCurLoc, locdiff);
-
-		// Now we calculate how much of the difference we cover in the time allotted.
-		// The equation is (Damp)^(time)
 		dampfactor = 1.0-dampfactor;	// We must exponent the amount LEFT rather than the amount bled off
-		dtime = (float)(cg.time-cameraLastFrame) * (1.0/(float)CAMERA_DAMP_INTERVAL);	// Our dampfactor is geared towards a time interval equal to "1".
 
-		// Note that since there are a finite number of "practical" delta millisecond values possible, 
-		// the ratio should be initialized into a chart ultimately.
-		ratio = Q_powf(dampfactor, dtime);
-		
-		// This value is how much distance is "left" from the ideal.
-		VectorMA(cameraIdealLoc, -ratio, locdiff, cameraCurLoc);
-		/////////////////////////////////////////////////////////////////////////////////////////////////////////
+		if ( mov_camerafps.integer >= CAMERA_MIN_FPS )
+		{	// FPS-independent camera damping by fau
+			vec3_t	newDelta;
+			vec3_t	velocity;
+			vec3_t	shift;
+			float	invdtime;
+			float	timeadjfactor;
+			float	codampfactor;
+			int		simulationtime;
+			float	physicstime;
+
+			// use physics time to get a real velocity
+			physicstime = cg.predictedPlayerState.commandTime - cameraLastTime;
+			physicstime += cg.predictedTimeFrac - cameraLastTimeFrac;
+			if (physicstime <= 0.0f)
+				return;
+			simulationtime = 1000 / mov_camerafps.integer;
+			dtime = physicstime / simulationtime;
+			invdtime = simulationtime / physicstime;
+			timeadjfactor = powf(dampfactor, dtime);
+			// velocity is in units / simulated frame time
+			VectorScale(idealDelta, invdtime, velocity);
+			// shift = velocity * dampfactor / (1 - dampfactor)
+			codampfactor = dampfactor / (1.0f - dampfactor);
+			VectorScale(velocity, codampfactor, shift);
+			// delta(dtime) = dampfactor^dtime * (delta(0) + shift) - shift
+			newDelta[0] = timeadjfactor * (oldDelta[0] + shift[0]) - shift[0];
+			newDelta[1] = timeadjfactor * (oldDelta[1] + shift[1]) - shift[1];
+			newDelta[2] = timeadjfactor * (oldDelta[2] + shift[2]) - shift[2];
+
+			VectorAdd(cameraIdealLoc, newDelta, cameraCurLoc);
+		}
+		else
+		{
+			// Calculate the difference from the current position to the new one.
+			VectorSubtract(cameraIdealLoc, cameraCurLoc, locdiff);
+
+			// Now we calculate how much of the difference we cover in the time allotted.
+			// The equation is (Damp)^(time)
+			// dtime = (float)(cg.time-cameraLastFrame) * (1.0/(float)CAMERA_DAMP_INTERVAL);	// Our dampfactor is geared towards a time interval equal to "1".
+
+			// Note that since there are a finite number of "practical" delta millisecond values possible,
+			// the ratio should be initialized into a chart ultimately.
+			// ratio = powi(dampfactor, dtime);
+
+			// fau - and this is how original powi really worked in mp when fps > 20
+			ratio = dampfactor;
+
+			// This value is how much distance is "left" from the ideal.
+			VectorMA(cameraIdealLoc, -ratio, locdiff, cameraCurLoc);
+			/////////////////////////////////////////////////////////////////////////////////////////////////////////
+		}
 	}
 
 	// Now we trace from the new target location to the new view location, to make sure there is nothing in the way.
@@ -503,6 +596,7 @@ static void CG_OffsetThirdPersonView( void )
 	vec3_t diff;
 	float thirdPersonHorzOffset = cg_thirdPersonHorzOffset.value;
 	float deltayaw;
+	float dtime;
 
 	cameraStiffFactor = 0.0;
 
@@ -521,9 +615,11 @@ static void CG_OffsetThirdPersonView( void )
 	}
 
 	// The next thing to do is to see if we need to calculate a new camera target location.
+	dtime = cg.predictedPlayerState.commandTime - cameraLastTime;
+	dtime += cg.predictedTimeFrac - cameraLastTimeFrac;
 
 	// If we went back in time for some reason, or if we just started, reset the sample.
-	if (cameraLastFrame == 0 || cameraLastFrame > cg.time)
+	if (cameraLastTime == 0 || dtime < 0.0f)
 	{
 		CG_ResetThirdPersonViewDamp();
 	}
@@ -546,7 +642,15 @@ static void CG_OffsetThirdPersonView( void )
 		{ // Normalize this angle so that it is between 0 and 180.
 			deltayaw = fabs(deltayaw - 360.0f);
 		}
-		cameraStiffFactor = deltayaw / (float)(cg.time-cameraLastFrame);
+		if (mov_camerafps.integer >= CAMERA_MIN_FPS) {
+			if ( dtime > 0.0f ) {
+				cameraStiffFactor = deltayaw / dtime;
+			} else {
+				cameraStiffFactor = 0.0f;
+			}
+		} else {
+			cameraStiffFactor = deltayaw / (cg.time - cg.oldTime);
+		}
 		if (cameraStiffFactor < 1.0)
 		{
 			cameraStiffFactor = 0.0;
@@ -594,7 +698,8 @@ static void CG_OffsetThirdPersonView( void )
 	// ...and of course we should copy the new view location to the proper spot too.
 	VectorCopy(cameraCurLoc, cg.refdef.vieworg);
 
-	cameraLastFrame=cg.time;
+	cameraLastTime = cg.predictedPlayerState.commandTime;
+	cameraLastTimeFrac = cg.predictedTimeFrac;
 }
 
 

--- a/CODE-mp/game/q_math.c
+++ b/CODE-mp/game/q_math.c
@@ -1466,12 +1466,3 @@ int irand(int min, int max)
 	result = ((result * (max - min)) >> 15) + min;
 	return(result);
 }
-
-float Q_powf ( float x, int y )
-{
-	float r = x;
-	for ( y--; y>0; y-- )
-		r = r * r;
-	return r;
-}
-

--- a/CODE-mp/game/q_shared.h
+++ b/CODE-mp/game/q_shared.h
@@ -893,8 +893,6 @@ float Q_rsqrt( float f );		// reciprocal square root
 signed char ClampChar( int i );
 signed short ClampShort( int i );
 
-float Q_powf ( float x, int y );
-
 // this isn't a real cheap function to call!
 int DirToByte( vec3_t dir );
 void ByteToDir( int b, vec3_t dir );


### PR DESCRIPTION
## Explanation

Original camera damping implementation was broken in such a way that it was well behaved only in perfect conditions - stable fps, server fps and connection. Once something went wrong, it was **escalating** all such issues. For example a snapshot packet drop that would cause only minuscule and barely noticeable warp in first person, causes original third person camera to do a big jump.

This is especially visible when one of these things happens:

- fps drop – doesn't concern jomme
- server fps drop – on non-dedicated server they happen regularly, this is why local demos appear so "lagged". Also some servers run with sv_fps 100 and don't always hit the limit.
- unstable connection or low timenudge setting – something that often makes demos jerky.

This code "fixes" third person camera damping in such a way that in perfect conditions it behaves *exactly* like original and in bad conditions it doesn't escalate warping (there is the same amount of warp as in first person view). Moreover you can emulate original damping on any desired fps (low fps values damp more).

Why fix camera damping when you can just use "stiff" third person camera with `cg_cameradamptarget 0`?
You may ask why was it added to the game in the first place – all good third person games have it. It makes everything look smoother, better, give you a better sense of dynamic movement and speed.

## Comparison
https://www.youtube.com/watch?v=QW_PcR6CM6M
First demo is a normal demo recorded on local, non-dedicated server. You can try for yourself, this is what happens due to irregular server framerate.
Second demo was recorded by miso with high ping (~200) on online server. You can see how his model appears to be warping on high speed with original damping (even though it's actually camera warping!). Also notice how the camera goes away as he gains speed giving a nice feeling.

Miso uses my cgame with this code to record his speedrunning demos. They look perfectly smooth:
https://www.youtube.com/watch?v=GTdjZcXRDdw

## Notes

This commit uses mov_camerafps name for setting emulated camera fps. Normally I use cg_camerafps but I guess this fits jomme convention better.
mov_camerafps is set to 125 as default. 0 reverts back to original code which. Do with the default as you wish, 125 gives a rather stiff camera.

Also I have a more refactored version of this code (see here: https://github.com/aufau/SaberMod/blob/master/code/cgame/cg_view.c#L240-L654), but with this one it's easier to compare changes to original.

To potentially use it in a qvm mod one needs a bg_lib.c powf implementation. I wrote one for it, it can be found in sabermod's source code.

I release this code under GPL2 and I wish it will be respected. If someone wants to incorporate it in a closed source mod please contact me first.